### PR TITLE
fix: correct GitHub Pages base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import { componentTagger } from "lovable-tagger";
 export default defineConfig(({ mode }) => ({
   // GitHub Pages deployment configuration
   // Use repository path for GitHub Pages, root path for custom domain
-  base: '/',
+  base: mode === 'development' ? '/' : '/eninnov-nexus/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- correct Vite base path so built app uses `/eninnov-nexus/` on Pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden; Fast refresh only works when a file only exports components; An interface declaring no members is equivalent to its supertype)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75079c91c8328b93df2b4e2a75a52